### PR TITLE
Replace sessions with client-sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "optimist": "0.2.8",
+        "client-sessions": "0.0.5",
         "cradle": "0.6.3",
         "express": "3.0.6",
         "ejs": "0.8.3",

--- a/server/bin/app
+++ b/server/bin/app
@@ -5,6 +5,7 @@
 var api = require('../lib/api'),
     https = require('https'),
     qs = require('qs'),
+    clientSessions = require('client-sessions'),
     config = require('../lib/config'),
     express = require('express'),
     app = express();
@@ -16,7 +17,12 @@ app.use(express.static(__dirname + '/../../static'));
 
 app.use(express.bodyParser());
 app.use(express.cookieParser());
-app.use(express.session({ secret: config.session_secret}));
+var sess_config = config.client_sessions;
+app.use(clientSessions({
+  cookieName: sess_config.cookie_name,
+  secret:     sess_config.secret,
+  duration:   sess_config.duration
+}));
 app.use(express.csrf());
 
 app.get('/', function(req, res){
@@ -50,7 +56,7 @@ app.post('/auth', function(req, res) {
                 
             } else {
                 console.error(verified.reason);
-                req.session.destroy();
+                req.session.reset();
             }
             res.redirect('/');
         });
@@ -82,7 +88,7 @@ app.post('/auth', function(req, res) {
 });
 
 app.get('/logout', function(req, res) {
-    req.session.destroy();
+    req.session.reset();
     res.redirect('/');
 });
 

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -16,6 +16,11 @@
     },
     "session_secret": "dashkpidashkpidashkpi",
     "verification_audience": "localhost:3434",
+    "client_sessions": {
+      "cookie_name": "session_state",
+      "secret": "dashkpidashkpidashkpi",
+      "duration": 1209600000
+    },
     "segmentations": {
         "OS": [ "Windows 7", "Windows XP", "Macintosh", "Linux", "Android" ],
         "Browser": [ "Firefox", "Chrome", "MSIE", "Safari" ],


### PR DESCRIPTION
To make kpi-dashboard consistent with our other products, and to keep sessions alive passed a server restart, we should add `client-sessions`.

This sets us up for being able to scale the dashboard without a server side session store.

Note: to test, you probably should clear your old cookies from your test env.

/CC @kparlante 
