### PR TITLE
Fix for "new user flow over time" graph

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -38,6 +38,8 @@ var VIEWS = {
 
         return values.reduce(function(accumulated, current) {
           var steps = Object.keys(current.steps);
+          var total = accumulated.total + current.total;
+          
           steps.forEach(function(step) {
             if(! (step in accumulated.steps)) {
               accumulated.steps[step] = 0;
@@ -45,13 +47,12 @@ var VIEWS = {
 
             // The fraction of users who completed this step is the
             // weighted average of the results being merged.
-            var total = accumulated.total + current.total;
             accumulated.steps[step] =
               current.steps[step] * current.total / total +
               accumulated.steps[step] * accumulated.total / total;
-
-            accumulated.total = total;
           });
+          
+          accumulated.total = total;
 
           return accumulated;
         }, initial);


### PR DESCRIPTION
The map/reduce was updating the accumulated total for every step in the array, which was deflating the % for each step. The updated graph will give a much more accurate picture.
