### PR TITLE
Ignore 'canceled' flows that aren't new users

### DIFF
--- a/server/lib/data.js
+++ b/server/lib/data.js
@@ -159,6 +159,10 @@ exports.newUserSteps = function(datum) {
     if(events.indexOf('screen.set_password') === -1) { // not a new user
         return steps;
     }
+    
+    if(events.indexOf('authenticate.enter_password') !== -1) { // not a new user
+        return steps;
+    }
 
     config.get('flows').new_user.forEach(function(step) {
         if(events.indexOf(step[1]) !== -1) {

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -103,6 +103,8 @@ var VIEWS = {
 
         return values.reduce(function(accumulated, current) {
           var steps = Object.keys(current.steps);
+          var total = accumulated.total + current.total;
+          
           steps.forEach(function(step) {
             if(! (step in accumulated.steps)) {
               accumulated.steps[step] = 0;
@@ -110,13 +112,12 @@ var VIEWS = {
 
             // The fraction of users who completed this step is the
             // weighted average of the results being merged.
-            var total = accumulated.total + current.total;
             accumulated.steps[step] =
               current.steps[step] * current.total / total +
               accumulated.steps[step] * accumulated.total / total;
 
-            accumulated.total = total;
           });
+          accumulated.total = total;
 
           return accumulated;
         }, initial);


### PR DESCRIPTION
This fixes https://github.com/mozilla/kpi-dashboard/issues/16, where we were seeing users hit Stage 1 and Stage 4 without the intervening stages (email verification). The scenario is described here: https://github.com/mozilla/browserid/issues/3359. (The dashboard doesn't use new_account at the moment, but we should probably correct it in the data). The logic behind the fix: if the user is prompted to enter a password, this isn't a new user flow.

You can see the results of the fix on kpi-prod-stage, a staging area for dashboard fixes that uses production data. (Same privacy/security settings as production).

@ozten or @shane-tomlinson, a review would be great, no rush
