### PR TITLE
Add FirefoxOS and screen size buckets to segmentations

### DIFF
--- a/server/bin/update
+++ b/server/bin/update
@@ -4,12 +4,15 @@
 
 var db = require('../lib/db');
 
+var ONE_MONTH = 2592000000;
+var TWO_WEEKS = 1209600000;
+
 // Defaults to last 30 days 
 var argv = require('optimist')
 .usage('Pull kpi data from kpiggybank')
 .alias('s', 'start')
 .describe('s', 'start timestamp')
-.default('s', Date.now() - 2592000000)
+.default('s', Date.now() - ONE_MONTH)
 .alias('e', 'end')
 .describe('e', 'end timestamp')
 .default('e', Date.now())
@@ -21,11 +24,21 @@ var args = argv.argv;
 if (args.h) {
   argv.showHelp();
   process.exit(1);
-} else {
+} else {  
   var options = {
-    "start" : args.s,
-    "end" : args.e
+    "start" : args.s
   };
-  
-  db.populateDatabase(options);
+
+  while (options["start"] < args.e) {
+    var interval = options["start"] + TWO_WEEKS;
+    if (interval > args.e) {
+      options["end"] = args.e;
+    } else {
+      options["end"] = interval;
+    }
+    console.log("Populating database: " + options["start"] + " - " + options["end"]);
+    db.populateDatabase(options);
+    options["start"] = interval + 1;
+  }
 }
+

--- a/server/config/production.json
+++ b/server/config/production.json
@@ -1,8 +1,8 @@
 {
   "segmentations": {
-        "OS": [ "Windows 8", "Windows 7", "Windows Vista", "Windows XP", "Macintosh", "Linux", "Android", "iOS" ],
+        "OS": [ "Windows 8", "Windows 7", "Windows Vista", "Windows XP", "Macintosh", "Linux", "Android", "iOS", "FirefoxOS" ],
         "Browser": [ "Firefox", "Chrome", "MSIE", "Safari" ],
-        "Screen": [ "1366×768", "1024×768", "1280×800", "1280×1024", "1440×900", "1920×1080"],
+        "Screen": [ "Desktop (>= 1024)", "Tablet Profile", "Mobile (<= 640)"],
         "Emails": [ "0", "1", "2", "3+", "Unknown" ],
         "Locale": [ "English", "Spanish", "Portuguese - Brazil", "Polish", "Dutch", "Italian", "French", "German", "Russian", "Turkish" ],
         "API": [ "get", "getVerifiedEmail", "watch",  "watch with onready", "internal"]

--- a/server/lib/data.js
+++ b/server/lib/data.js
@@ -98,8 +98,13 @@ exports.getSegmentation = function(metric, datum) {
       break;
     case "Screen":
       if('screen_size' in datum.value && 'width' in datum.value.screen_size) {
-        value = datum.value.screen_size.width + '×' +
-                datum.value.screen_size.height;
+        if (datum.value.screen_size.width >= 1024) {
+          value = "Desktop (>= 1024)";
+        } else if (datum.value.screen_size.width <= 640 ){
+          value = "Mobile (<= 640)";
+        } else {
+          value = "Tablet Profile";
+        }
       } else {
         value = "Unknown";
       }

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -427,7 +427,6 @@ exports.populateDatabase = function(options) {
       // Insert it into the database. Conveniently, it already has a UUID,
       // from the last time it was in CouchDB.
       db.save(datum.id, datum.value);
-      console.log("ID: " + datum.id);
     });
   });
 };


### PR DESCRIPTION
Fixes #58. Also modifies the update script to grab data from kpiggybank in smaller intervals, instead of one big request.
