### PR TITLE
Adding new_user_per_day graph

### DIFF
--- a/server/lib/api.js
+++ b/server/lib/api.js
@@ -138,6 +138,10 @@ exports.new_user = function(req, res) {
     getReport(reports.new_user, req, res);
 };
 
+exports.new_user_per_day = function(req, res) {
+    getReport(reports.new_user_per_day, req, res);
+}
+
 /**
  * Processes request for steps in new user flow
  */

--- a/server/views/dashboard.ejs
+++ b/server/views/dashboard.ejs
@@ -34,6 +34,9 @@
                         <a href="#new_user_success" data-toggle="tab">New user success</a>
                     </li>
                     <li>
+                        <a href="#new_user_per_day" data-toggle="tab">New users per day</a>
+                    </li>
+                    <li>
                         <a href="#password_reset" data-toggle="tab">Password reset flow</a>
                     </li>
                     <li>
@@ -294,6 +297,43 @@
                             </div>
                         </div>
                     </div>
+                    
+                    <div id="new_user_per_day" class="tab-pane form-inline">
+                        <h2>How many new users per day?</h2>
+                        
+                        <div class="chart"></div>
+                        <div class="timeline"></div>
+
+                        <div class="chart-controls">
+                            <div class="date-select">
+                                <p>
+                                    From
+                                    <input type="date" class="start" placeholder="YYYY-MM-DD">
+                                    to
+                                    <input type="date" class="end" placeholder="YYYY-MM-DD">
+                                </p>
+                                <div class="slider date-slider"></div>
+                            </div>
+                            <p class="controls">Show
+                                <label class="control-label inline">
+                                    <input name="sites-segment-enabled" class="segment-enabled" type="radio" value="no" checked="checked"> cumulative
+                                </label>
+                                <label class="control-label inline">
+                                    <input name="sites-segment-enabled" class="segment-enabled" type="radio" value="yes"> segmentation
+                                </label>
+                            </p>
+
+                            <div class="segment-options">
+                                <p>Segment by
+                                    <select class="segment-select input-small">
+                                    </select>
+                                </p>
+                                <div class="segment-boxes">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
 
 
                 </div>

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -108,6 +108,20 @@ var _reports = {
             renderer: 'line',
             segmentation: null
         },
+    new_user_per_day:
+        {
+            kpi: 'new_user_per_day',
+            tab: $('#new_user_per_day'),
+            dataToSeries: dataToTimeSeries,
+            graphDecorator: initTimeGraph,
+            update: updateGraph,
+            graph: null,
+            series: null,
+            start: dateToTimestamp(EARLIEST_DATE),
+            end: dateToTimestamp(LATEST_DATE),
+            renderer: 'line',
+            segmentation: null
+        },
     // Report: median of number_sites_logged_in
     sites:
         {
@@ -895,7 +909,7 @@ stepReport(_reports.password_reset);
 })(_reports.new_user);
 
 // Setup report for sites and assertions
-[_reports.sites, _reports.assertions, _reports.new_user_success]
+[_reports.sites, _reports.assertions, _reports.new_user_success, _reports.new_user_per_day]
 .forEach(function(report) {
     loadData(report, function() {
         drawGraph(report, report.series);


### PR DESCRIPTION
Implements #23 -- adding a graph for # of new users per day. Includes segmentations. Uses existing new_user couchdb views to build the reports.
