### PR TITLE
Fix the login loop of death.

### DIFF
--- a/server/bin/app
+++ b/server/bin/app
@@ -64,11 +64,11 @@ app.post('/auth', function(req, res) {
                     req.session.mozilla_email = null;
                 }
 
+                res.redirect('/');
             } else {
                 console.error(verified.reason);
-                req.session.reset();
+                res.redirect('/force-logout');
             }
-            res.redirect('/');
         });
     };
 
@@ -97,6 +97,11 @@ app.post('/auth', function(req, res) {
     request.end();
 });
 
+app.get('/force-logout', function(req, res) {
+  req.session.reset();
+  res.render('force-logout');
+});
+
 app.get('/logout', function(req, res) {
     req.session.reset();
     res.redirect('/');
@@ -116,5 +121,7 @@ app.get('*', function(req,res) {
     res.send('Resource not found', 404);
 });
 
-app.listen(process.env['PORT'] || 3434);
+var port = process.env['PORT'] || 3434;
+console.log("listening on port " + port);
+app.listen(port);
 

--- a/server/views/force-logout.ejs
+++ b/server/views/force-logout.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>KPI Dashboard - force logout</title>
+    </head>
+    <body>
+        <script type="text/javascript" src="https://login.persona.org/include.js"></script>
+        <script type="text/javascript" src="js/force-logout.js"></script>
+    </body>
+</html>
+

--- a/static/js/force-logout.js
+++ b/static/js/force-logout.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This forces a logout on the user.
+(function() {
+  "use strict";
+
+  navigator.id.watch({
+    onlogin: function() {
+      // ignore this, we are forcing the user to sign out.
+    },
+    onlogout: function() {
+      document.location = "/";
+    }
+  });
+  navigator.id.logout();
+}());
+


### PR DESCRIPTION
- If there is an error verifying the assertion, send the user to the /force-logout page, where navigator.id.logout is called.

fixes #80
