### PR TITLE
New user bounce; IdP segmentation added

### DIFF
--- a/server/config/production.json
+++ b/server/config/production.json
@@ -5,7 +5,8 @@
         "Screen": [ "Desktop (>= 1024)", "Tablet Profile", "Mobile (<= 640)"],
         "Emails": [ "0", "1", "2", "3+", "Unknown" ],
         "Locale": [ "English", "Spanish", "Portuguese - Brazil", "Polish", "Dutch", "Italian", "French", "German", "Russian", "Turkish" ],
-        "API": [ "get", "getVerifiedEmail", "watch",  "watch with onready", "internal"]
+        "API": [ "get", "getVerifiedEmail", "watch",  "watch with onready", "internal"],
+        "EmailType": [ "IdP", "Fallback"]
     },
     "aliases": {
         "Windows NT 6.2": "Windows 8",
@@ -26,7 +27,9 @@
         "pl" : "Polish",
         "tr" : "Turkish",
         "ru" : "Russian",
-        "nl" : "Dutch"
+        "nl" : "Dutch",
+        "primary" : "IdP",
+        "secondary" : "Fallback"
     },
     "flows": {
       "new_user": [

--- a/server/config/production.json
+++ b/server/config/production.json
@@ -36,10 +36,9 @@
         [ "4 - Logged in (assertion generated)", "assertion_generated" ]
       ],
       "password_reset": [
-        [ "1 - Begin password reset", "screen.reset_password" ],
-        [ "2 - Choose new password", "user.reset_password_staged" ],
-        [ "3 - Email verified", "user.reset_password_confirmed" ],
-        [ "4 - Logged in (assertion generated)", "assertion_generated" ]
+        [ "1 - Begin password reset", "user.reset_password_staged" ],
+        [ "2 - New password confirmed", "user.reset_password_confirmed" ],
+        [ "3 - Logged in (assertion generated)", "assertion_generated" ]
       ],
       "general_progress": [
         [ "0 - Blob sent", ""],

--- a/server/lib/api.js
+++ b/server/lib/api.js
@@ -146,6 +146,10 @@ exports.bounce_rate = function(req, res) {
     getReport(reports.bounce_rate, req, res);
 }
 
+exports.new_user_bounce = function(req, res) {
+    getReport(reports.new_user_bounce, req, res);
+}
+
 /**
  * Processes request for steps in new user flow
  */

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -41,7 +41,8 @@ var conf = module.exports = convict({
     Screen: 'array { string }* = [ "1024×768", "1680×1050", "etc"]',
     Emails: 'array { string }* = [ "0", "1", "2", "3+", "Unknown" ]',
     Locale: 'array { string }* = [ "en-us", "en-US" ]',
-    API: 'array { string }* = [ "get", "watch" ]'
+    API: 'array { string }* = [ "get", "watch" ]',
+    EmailType: 'array { string }* = [ "IdP", "Fallback"]'
   },
   aliases: 'object { } * = {"Windows NT 6.1": "Windows 7"}',
   flows: 'object { } *',

--- a/server/lib/data.js
+++ b/server/lib/data.js
@@ -257,7 +257,7 @@ exports.passwordResetSteps = function(datum) {
     var steps = [];
     var events = eventList(datum);
 
-    if(events.indexOf('screen.reset_password') === -1) { // not a password reset
+    if(events.indexOf('user.reset_password_staged') === -1) { // not a password reset
         return steps;
     }
 

--- a/server/lib/data.js
+++ b/server/lib/data.js
@@ -105,8 +105,6 @@ exports.getSegmentation = function(metric, datum) {
         } else {
           value = "Tablet Profile";
         }
-      } else {
-        value = "Unknown";
       }
       break;
     case "Emails":
@@ -116,8 +114,6 @@ exports.getSegmentation = function(metric, datum) {
         } else if(datum.value.number_emails >= 3) {
           value = "3+";
         }
-      } else {
-        value = "Unknown";
       }
       break;
     case "Locale":
@@ -126,10 +122,15 @@ exports.getSegmentation = function(metric, datum) {
     case "API":
       if('rp_api' in datum.value) {
         value = datum.value.rp_api;
-      } else {
-        value = "Unknown";
       }
       break;
+    case "EmailType":
+      if((datum.value.newUserSteps.length > 0) || (datum.value.passwordResetSteps.length > 0)) {
+        value = "Fallback";
+      }
+      if('email_type' in datum.value) {
+        value = datum.value.email_type;
+      }
     }
 
     if(value !== null && value in config.get('aliases')) {

--- a/server/lib/data.js
+++ b/server/lib/data.js
@@ -127,8 +127,7 @@ exports.getSegmentation = function(metric, datum) {
     case "EmailType":
       if((datum.value.newUserSteps.length > 0) || (datum.value.passwordResetSteps.length > 0)) {
         value = "Fallback";
-      }
-      if('email_type' in datum.value) {
+      } else if('email_type' in datum.value) {
         value = datum.value.email_type;
       }
     }

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -113,18 +113,6 @@ var VIEWS = {
     }
   },
 
-  new_user_success: {
-    map: function(doc) {
-      if(doc.newUserSteps.length > 0) { // Only count new users
-        var lastStep = doc.newUserSteps[doc.newUserSteps.length - 1];
-        var success = (lastStep === "4 - Logged in (assertion generated)");
-        emit(doc.date, success ? 1 : 0);
-      }
-    },
-
-    reduce: '_stats'
-  },
-
   assertions: {
     map: function(doc) {
       emit(doc.date, 1);
@@ -312,28 +300,6 @@ var VIEWS = {
   var segmentations = Object.keys(data.getSegmentations());
   segmentations.forEach(function(segmentation) {
     VIEWS['sites_' + segmentation] = {
-      map: getMapBySegment(segmentation),
-      reduce: '_stats'
-    };
-  });
-})();
-
-/** Initialize new_user_success report */
-(function() {
-  var getMapBySegment = function(segmentation) {
-    return function(doc) {
-      if(doc.newUserSteps.length > 0) { // Only count new users
-        var lastStep = doc.newUserSteps[doc.newUserSteps.length - 1];
-        var success = (lastStep === "4 - Logged in (assertion generated)");
-        emit([doc.date, doc["---SEGMENTATION---"]], success ? 1 : 0);
-      }
-    }.toString().replace('---SEGMENTATION---', segmentation);
-
-  };
-
-  var segmentations = Object.keys(data.getSegmentations());
-  segmentations.forEach(function(segmentation) {
-    VIEWS['new_user_success_' + segmentation] = {
       map: getMapBySegment(segmentation),
       reduce: '_stats'
     };

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -367,7 +367,7 @@ exports.populateDatabase = function(options) {
   data.getData(options, function(rawData) {
     rawData.forEach(function(datum) {
       // Ignore blobs with empty event streams: they are the result of errors
-      if(!data.value.event_stream || datum.value.event_stream.length === 0) {
+      if(!datum.value.event_stream || datum.value.event_stream.length === 0) {
         return;
       }
 

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -166,6 +166,40 @@ var VIEWS = {
         return accumulated;
       }, {});
     }
+  },
+  
+  new_user_bounce: {
+    map: function(doc) {
+      var events = doc.event_stream.map(function(eventPair) {
+        return eventPair[0];
+      });
+
+      if (doc.generalProgressSteps.indexOf('1 - Dialog shown') !== -1) {
+        if (doc.generalProgressSteps.indexOf('2 - User engaged') === -1) {
+            emit(doc.date, {"assertion":0, "bounce":1, "fail":0, "fallback":0, "idp":0});
+        } else if (events.indexOf('assertion_generated') !== -1 ) {
+          if (doc.newUserSteps.length !== 0) {
+        	emit(doc.date, {"assertion":0, "bounce":0, "fail":0, "fallback":1, "idp":0});
+          } else if (doc.new_account && events.indexOf('screen.provision_primary_user') !== -1) {
+            emit(doc.date, {"assertion":0, "bounce":0, "fail":0, "fallback":0, "idp":1});
+          } else {
+            emit(doc.date, {"assertion":1, "bounce":0, "fail":0, "fallback":0, "idp":0});
+          }
+        } else {
+            emit(doc.date, {"assertion":0, "bounce":0, "fail":1, "fallback":0, "idp":0});
+        }
+      }
+    },
+    
+    reduce: function (keys, values, rereduce) {         
+      return values.reduce(function(accumulated, current) {
+        var outcomes = Object.keys(current);
+        outcomes.forEach(function(outcome) {
+          accumulated[outcome] = accumulated[outcome] + current[outcome];
+        });
+        return accumulated;
+      });
+    }
   }
 };
 

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -39,7 +39,7 @@ var VIEWS = {
         return values.reduce(function(accumulated, current) {
           var steps = Object.keys(current.steps);
           var total = accumulated.total + current.total;
-          
+
           steps.forEach(function(step) {
             if(!accumulated.steps.hasOwnProperty(step)) {
               accumulated.steps[step] = 0;
@@ -89,7 +89,7 @@ var VIEWS = {
   new_user: {
     map: function(doc) {
       if(doc.newUserSteps.length > 0) { // Only count new users
-        var steps = {}
+        var steps = {};
         doc.newUserSteps.forEach(function(step) {
           steps[step] = 1;
         });
@@ -140,18 +140,18 @@ var VIEWS = {
 
     reduce: '_stats'
   },
-  
+
   general_progress: {
     map: function(doc) {
       if(doc.generalProgressSteps.length > 0) { // Only count new users
-        var steps = {}
+        var steps = {};
         doc.generalProgressSteps.forEach(function(step) {
           steps[step] = 1;
         });
         emit(doc.date, steps);
       }
     },
-    
+
     reduce: function(keys, values, rereduce) {
       return values.reduce(function(accumulated, current) {
         var steps = Object.keys(current);
@@ -182,14 +182,14 @@ var VIEWS = {
    *     segmentation with the one we want.
    */
   var getMapBySegment = function(segmentation) {
-    return function(doc) {      
+    return function(doc) {
       if(doc.newUserSteps.length > 0) {
-        
-        var steps = {}
+
+        var steps = {};
         doc.newUserSteps.forEach(function(step) {
           steps[step] = 1;
         });
-        emit([doc.date, doc["---SEGMENTATION---"]], steps);        
+        emit([doc.date, doc["---SEGMENTATION---"]], steps);
       }
     }.toString().replace('---SEGMENTATION---', segmentation);
   };
@@ -209,7 +209,7 @@ var VIEWS = {
       });
 
       return accumulated;
-    }, {});    
+    }, {});
   };
 
   var segmentations = Object.keys(data.getSegmentations());
@@ -317,17 +317,17 @@ var DOCUMENT = {
  */
 function initDatabase(callback) {
   db.exists(function(err, exists) {
-    if(err) throw(err);
+    if(err) return callback(err);
 
     if(exists) {
       // Update the views stored in the database to the current version.
       // Does this regardless of the current state of the design document
       // (i.e., even if it is up-to-date).
       db.get('_design/' + NAME, function(err, doc) {
-        if(err) throw(err);
+        if(err) return callback(err);
 
         db.save('_design/' + NAME, doc._rev, DOCUMENT, function(err, res) {
-          if(err) throw err;
+          if(err) return callback(err);
 
           callback();
         });
@@ -336,7 +336,7 @@ function initDatabase(callback) {
       // Create database and initialize views
       db.create(function(err) {
         db.save('_design/' + NAME, DOCUMENT, function(err) {
-          if(err) throw err;
+          if(err) return callback(err);
 
           callback();
         });
@@ -348,7 +348,11 @@ function initDatabase(callback) {
 
 // On load:
 (function() {
-  initDatabase(function() {
+  initDatabase(function(err) {
+    if (err) {
+      return console.log(
+                "There was an error initializing the database" + String(err));
+    }
     exports.db = db;
   });
 })();
@@ -363,7 +367,7 @@ exports.populateDatabase = function(options) {
   data.getData(options, function(rawData) {
     rawData.forEach(function(datum) {
       // Ignore blobs with empty event streams: they are the result of errors
-      if(datum.value.event_stream.length === 0) {
+      if(!data.value.event_stream || datum.value.event_stream.length === 0) {
         return;
       }
 

--- a/server/lib/reports.js
+++ b/server/lib/reports.js
@@ -137,12 +137,13 @@ exports.new_user_success = function(segmentation, start, end, callback) {
       dbOptions.endkey = [ util.getDateStringFromUnixTime(end) ];
     }
 
-    db.view('new_user_success_' + segmentation, dbOptions, function(response) {
+    db.view('new_user_bounce_' + segmentation, dbOptions, function(response) {
       var result = {};
       response.forEach(function(row) {
-        var date = row.key[0],
-        segment = row.key[1],
-        mean = row.value.sum / row.value.count;
+        var date = row.key[0];
+        var segment = row.key[1];
+        var success = row.value['idp'] + row.value['fallback'];
+        var failure = row.value['bounce'] + row.value['fail'];
 
         if(! (segment in result)) {
           result[segment] = [];
@@ -150,7 +151,7 @@ exports.new_user_success = function(segmentation, start, end, callback) {
 
         result[segment].push({
           category: date,
-          value: mean
+          value: success / (success + failure)
         });
       });
 
@@ -164,13 +165,15 @@ exports.new_user_success = function(segmentation, start, end, callback) {
       dbOptions.endkey = util.getDateStringFromUnixTime(end);
     }
 
-    db.view('new_user_success', dbOptions, function(response) {
+    db.view('new_user_bounce', dbOptions, function(response) {
       var dates = [];
       response.forEach(function(row) {
-        var stats = row.value;
+        var success = row.value['idp'] + row.value['fallback'];
+        var failure = row.value['bounce'] + row.value['fail'];
+        
         dates.push({
           category: row.key, // date
-          value: stats.sum / stats.count // mean
+          value: success / (success + failure)
         });
       });
 

--- a/server/lib/reports.js
+++ b/server/lib/reports.js
@@ -383,17 +383,14 @@ exports.password_reset = function(start, end, callback) {
 
     dataByDate.forEach(function(datum) {
       var date = datum.key;
+      var total = datum.value[steps[0]];
 
       steps.forEach(function(step) {
-        var value;
-        if(! (step in datum.value.steps)) { // No data about this step
-          // That means no one completed it.
-          value = 0;
+        if(step in datum.value) { 
+          dataByStep[step][date] = datum.value[step]/total;
         } else {
-          value = datum.value.steps[step];
+          dataByStep[step][date] = 0;
         }
-
-        dataByStep[step][date] = value;
       });
     });
 

--- a/server/lib/reports.js
+++ b/server/lib/reports.js
@@ -263,9 +263,6 @@ exports.new_user_per_day = function(segmentation, start, end, callback) {
     group: true
   };
   
-  var step_names = data.newUserStepNames();
-  var last_step_name = step_names[step_names.length-1];
-  
   if (segmentation) {
     if(start) {
       dbOptions.startkey = [ util.getDateStringFromUnixTime(start) ];
@@ -274,7 +271,7 @@ exports.new_user_per_day = function(segmentation, start, end, callback) {
       dbOptions.endkey = [ util.getDateStringFromUnixTime(end) ];
     }
     
-    db.view('new_user_' + segmentation, dbOptions, function(response) {
+    db.view('new_user_bounce_' + segmentation, dbOptions, function(response) {
       var graph_data = {};
       
       response.forEach(function(row) {
@@ -287,7 +284,7 @@ exports.new_user_per_day = function(segmentation, start, end, callback) {
         
         graph_data[segment].push({
           category: date,
-          value: row.value[last_step_name]
+          value: row.value['idp'] + row.value['fallback']
         });
       });
       callback(graph_data);
@@ -301,12 +298,12 @@ exports.new_user_per_day = function(segmentation, start, end, callback) {
       dbOptions.endkey = util.getDateStringFromUnixTime(end);
     }
 
-    db.view('new_user', dbOptions, function(response) {
+    db.view('new_user_bounce', dbOptions, function(response) {
       var graph_data = [];
       response.forEach(function(row) {
         graph_data.push({
           category: row.key,
-          value: row.value[last_step_name]
+          value: row.value['idp'] + row.value['fallback']
         });
       });
       callback({ Total: graph_data });

--- a/server/lib/reports.js
+++ b/server/lib/reports.js
@@ -312,7 +312,7 @@ exports.new_user_per_day = function(segmentation, start, end, callback) {
       callback({ Total: graph_data });
     });
   }
-}
+};
 
 /**
  * Reports fraction of users at each step in the new user flow, over time
@@ -437,8 +437,7 @@ exports.general_progress_time = function(start, end, callback) {
 
     callback(dataByStep);
   });
-  
-}
+};
 
 exports.bounce_rate = function(segmentation, start, end, callback) {
   var dbOptions = {
@@ -463,6 +462,31 @@ exports.bounce_rate = function(segmentation, start, end, callback) {
     });
     callback({ Total: graph_data });
   });
-  
-  
 };
+
+exports.new_user_bounce = function(segmentation, start, end, callback) {
+  var dbOptions = {
+    group: true
+  };
+  
+  if(start) {
+    dbOptions.startkey = util.getDateStringFromUnixTime(start);
+  }
+  if(end) {
+    dbOptions.endkey = util.getDateStringFromUnixTime(end);
+  }
+  
+  db.view('new_user_bounce', dbOptions, function(response) {
+    var graph_data = [];
+    
+    response.forEach(function(row) {
+      graph_data.push({
+        category: row.key, //date
+        // % new users who bounce: assumes most/all failures are new users and most/all open/closes are new users
+        value: row.value['bounce'] / (row.value['bounce'] + row.value['idp'] + row.value['fallback'] + row.value['fail']) 
+      });
+    });
+    callback({ Total: graph_data });
+  });
+};
+

--- a/server/views/dashboard.ejs
+++ b/server/views/dashboard.ejs
@@ -46,6 +46,9 @@
                         <a href="#assertions" data-toggle="tab">Sign-in attempts</a>
                     </li>
                     <li>
+                        <a href="#new_user_bounce" data-toggle="tab">New user bounce rate</a>
+                    </li>
+                    <li>
                         <a href="#bounce_rate" data-toggle="tab">Bounce rate</a>
                     </li>
                     <li>
@@ -343,6 +346,26 @@
                         </div>
                     </div>
                     
+                    <div id="new_user_bounce" class="tab-pane form-inline">
+                      <h2>How many *new* users fail to engage with the dialog?</h2>
+                      
+                      <div class="chart"></div>
+                      <div class="timeline"></div>
+                      
+                      <div class="chart-controls">
+                        <div class="date-select">
+                          <p>
+                              From
+                              <input type="date" class="start" placeholder="YYYY-MM-DD">
+                              to
+                              <input type="date" class="end" placeholder="YYYY-MM-DD">
+                          </p>
+                          <div class="slider date-slider"></div>
+                        </div>
+                      </div>
+                      
+                    </div>
+                    
                     <div id="bounce_rate" class="tab-pane form-inline">
                       <h2>How many users fail to engage with the dialog?</h2>
                       
@@ -361,7 +384,6 @@
                         </div>
                       </div>
                     </div>
-                    
 
                     <div id="general_progress_time" class="step-report tab-pane form-inline">
                       <h2>Do users progress through the dialog?</h2>

--- a/server/views/dashboard.ejs
+++ b/server/views/dashboard.ejs
@@ -362,8 +362,24 @@
                           </p>
                           <div class="slider date-slider"></div>
                         </div>
+                        <p class="controls">Show
+                            <label class="control-label inline">
+                                <input name="sites-segment-enabled" class="segment-enabled" type="radio" value="no" checked="checked"> cumulative
+                            </label>
+                            <label class="control-label inline">
+                                <input name="sites-segment-enabled" class="segment-enabled" type="radio" value="yes"> segmentation
+                            </label>
+                        </p>
+
+                        <div class="segment-options">
+                            <p>Segment by
+                                <select class="segment-select input-small">
+                                </select>
+                            </p>
+                            <div class="segment-boxes">
+                            </div>
+                        </div>
                       </div>
-                      
                     </div>
                     
                     <div id="bounce_rate" class="tab-pane form-inline">

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -185,7 +185,21 @@ var _reports = {
               height: 300,
               padding: { vertical: 100, horizontal: 0 }
           }
-        }
+        },
+    new_user_bounce:
+        {
+          kpi: 'new_user_bounce',
+          tab: $('#new_user_bounce'),
+          dataToSeries: dataToTimeSeries,
+          graphDecorator: initTimeGraph,
+          update: updateGraph,
+          graph: null,
+          series: null,
+          start: dateToTimestamp(EARLIEST_DATE),
+          end: dateToTimestamp(LATEST_DATE),
+          renderer: 'line',
+          segmentation: null
+        },
 };
 
 var _milestones = [];
@@ -944,7 +958,8 @@ stepReport(_reports.general_progress_time);
 })(_reports.new_user);
 
 // Setup report for sites and assertions
-[_reports.sites, _reports.assertions, _reports.new_user_success, _reports.new_user_per_day, _reports.bounce_rate]
+[_reports.sites, _reports.assertions, _reports.new_user_success, 
+ _reports.new_user_per_day, _reports.bounce_rate, _reports.new_user_bounce]
 .forEach(function(report) {
     loadData(report, function() {
         drawGraph(report, report.series);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -4,7 +4,11 @@
 /*global $:false, Rickshaw:false, d3:false */
 
 $("#signin").click(function(e){
-  navigator.id.request();
+  navigator.id.request({
+    siteLogo: "https://developer.mozilla.org/files/3971/plain_sign_in_red.png",
+    siteName: "Persona #signin Analytics",
+    backgroundColor: "#2C2C2C"
+  });
 });
 
 $("#signout").click(function(e){
@@ -136,7 +140,7 @@ var _reports = {
             end: dateToTimestamp(LATEST_DATE),
             renderer: 'area',
             segmentation: null
-        }, 
+        },
     // Report: total number of data points
     assertions:
         {
@@ -247,13 +251,13 @@ window.onpopstate = function(event) {
         report = window.location.hash;
         // Does a tab with the requested ID exist?
         if($('[data-toggle="tab"][href="' + report + '"]').length > 0) { // Yes!
-            activateTab(report);   
+            activateTab(report);
         }
     } else { // No state, no hash
         // Just show the first report in this case.
         report = $($('[data-toggle="tab"]')[0]).attr('href');
         activateTab(report);
-    }    
+    }
 };
 
 window.onload = window.onpopstate;
@@ -303,7 +307,7 @@ function dataToTimeSeries(data) {
                 data: data[segment].map(function(d) {
                     return {
                         // convert date to timestamp to take advantage of
-                        // Rickshaw's built-in date handling 
+                        // Rickshaw's built-in date handling
                         x: dateToTimestamp(d.category),
                         y: d.value || 0
                     };
@@ -313,7 +317,7 @@ function dataToTimeSeries(data) {
     }
 
     Rickshaw.Series.zeroFill(series);
-    
+
     return series;
 }
 
@@ -425,7 +429,7 @@ function initStepGraph(report) {
     });
 
     yAxis.render();
-    
+
     var labels = function(step) {
       var map = {
         1.5: report.steps[1].substr(4),
@@ -435,7 +439,7 @@ function initStepGraph(report) {
       };
       return map[step];
     }
-    
+
     // Show steps as x axis labels
     var xAxis = new Rickshaw.Graph.Axis.X({
       graph: report.graph,
@@ -443,9 +447,9 @@ function initStepGraph(report) {
       orientation: 'bottom',
       tickFormat: labels
     });
-    
+
     xAxis.render();
-    
+
     initStepTable(report);
 }
 
@@ -459,7 +463,7 @@ function initStepTable(report) {
   var table = [1,2,3,4].map(function(step) {
     return {stage: report.steps[step], count:0, move:0, progress:0, completed:0 };
   });
-  
+
   var rawData = report.series;
   for (var i = 0; i < rawData.length; i++) {
     for (var j = 0; j < rawData[i].data.length; j++) {
@@ -467,26 +471,26 @@ function initStepTable(report) {
       table[step_number-1].count += rawData[i].data[j].y
     }
   }
-  
+
   // Calculate other measures, based on counts for each stage
   for (var i = 0; i < table.length; i++) {
     if (i < table.length -1) {
       var move = table[i+1].count / table[i].count;
       table[i].move = move.toFixed(2) * 100;
     }
-    
+
     var progress = table[i].count / table[0].count;
     table[i].progress = progress.toFixed(2) * 100;
-    
+
     var completed = table[table.length-1].count / table[i].count;
     table[i].completed = completed.toFixed(2) * 100;
   }
-  
+
   // Spit out rows for the HTML table
   table.forEach(function(step) {
     container.append('<tr><td>'+ step.stage +'</td><td>' + step.count + '</td><td>' + step.progress + '%</td><td>' + step.move + '%</td><td>' + step.completed + '%</td></tr>');
   });
-  
+
 }
 
 /**
@@ -539,7 +543,7 @@ function dateChanged(report) {
     ['start', 'end'].forEach(function(type) {
         var input = report.tab.find('input[type=date].' + type).val();
         var milliseconds = (new Date(input)).getTime(); // milliseconds since epoch
-        
+
         if(isNaN(milliseconds)) { // Not a valid date
             alert('Invalid date entered');
             return false;
@@ -599,7 +603,7 @@ function cumulativeToggled(report) {
             updateGraph(report);
         });
     } else {
-        segmentationChanged(report);        
+        segmentationChanged(report);
     }
 }
 
@@ -618,7 +622,7 @@ function getSelectedSegments(report) {
 
 /**
  * Updates which segments are displayed on the graph.
- * 
+ *
  * Since we already have data for all segments, no new data is needed;
  * we just create a series using only those segments we want and display that.
  *
@@ -673,7 +677,7 @@ function setupSegmentControls() {
 
                 // Add an "other" option
                 segmentations[category].push('Other');
-                
+
                 // Create a checkbox for each segment
                 segmentations[category].forEach(function(segment) {
                     $('.segment-' + category).append(
@@ -687,7 +691,7 @@ function setupSegmentControls() {
         $('input.segment-toggle').click(function(e) {
             var report = targetReport(e.target);
             var success = updateDisplayedSegments(report);
-            
+
             // If the update failed, leave the checkbox in its original state.
             // @see updateDisplayedSegments for why this might happen
             if(! success) {
@@ -808,7 +812,7 @@ var stepReport = function(report) {
                 .select('.paths')
                 .selectAll('path')
                 .data(data);
-            
+
             lines
                 .enter()
                 .append('svg:path')
@@ -902,7 +906,7 @@ stepReport(_reports.general_progress_time);
                 var graph_data = steps.map(function(step) {
                   var step_number = parseInt(step[0], 10);
                   report.steps[step_number] = step;
-                                    
+
                   // 100% of people will be present in the first step,
                   // so we add the number from the first step to the total.
                   if (step_number === 1) {
@@ -910,9 +914,9 @@ stepReport(_reports.general_progress_time);
                   }
 
                   return {
-                    x: step_number, 
+                    x: step_number,
                     y: segmentData[step]
-                  };                  
+                  };
                 });
 
                 series.push({
@@ -920,7 +924,7 @@ stepReport(_reports.general_progress_time);
                     color: palette.color(),
                     data: graph_data.sort(function(a,b) { return a.x - b.x; })  // sort by ascending date
                 });
-            }            
+            }
         }
 
         Rickshaw.Series.zeroFill(series);
@@ -993,7 +997,7 @@ $('input[type=date].end').val(LATEST_DATE);
 
             var startDate = timestampToDate(ui.values[0]);
             var endDate = timestampToDate(ui.values[1]);
-            
+
             $('input[type=date].start').val(startDate);
             $('input[type=date].end').val(endDate);
 


### PR DESCRIPTION
- Adds a new query and report (new_user_bounce), enabling new user bounce view (#60)
- Adds IdP vs Fallback segmentation (to all views with segmentations)
- new_user_per_day report uses new_user_bounce query to include IdP data (#69)
- fixes password reset flow (#47)
- updated %successful signins report to include IdP data (#70)
- removed unused queries where we can use new_user_bounce
